### PR TITLE
Improve error messages

### DIFF
--- a/prexview.py
+++ b/prexview.py
@@ -37,7 +37,7 @@ class PrexView(Singleton):
       'rateRemaining': response.headers['x-ratelimit-remaining'],
     }
 
-    if response.status_code is 200:
+    if response.status_code == 200:
       result['id'] = response.headers['x-transaction-id']
       result['file'] = response.content
       result['responseTime'] = response.headers['x-response-time']
@@ -47,14 +47,14 @@ class PrexView(Singleton):
   def __isJson(self, str):
     try:
       json = loads(str)
-    except ValueError, e:
+    except ValueError as e:
       return False
 
     return True
 
   def __checkOptions(self, _format, options):
     # JSON
-    if _format is 'json':
+    if _format == 'json':
       if type(options['json']) is str:
         if self.__isJson(options['json']) is not True:
           raise Exception('PrexView content must be a valid JSON string')
@@ -104,7 +104,7 @@ class PrexView(Singleton):
     return options
 
   def __checkToken(self):
-    if self.token is None or self.token is '':
+    if self.token is None or self.token == '':
       raise Exception('PrexView environment variable PXV_API_KEY must be set')
 
   def sendXML(self, content, options):

--- a/prexview.py
+++ b/prexview.py
@@ -28,8 +28,8 @@ class PrexView(Singleton):
 
     response = post(self._URL + 'transform', data = data, headers = headers)
 
-    if response.raise_for_status() is not None:
-      return None
+    if response.status_code != 200:
+      raise Exception(loads(response.content)['error'])
 
     result = {
       'rateLimit': response.headers['x-ratelimit-limit'],

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,7 +1,7 @@
 # coding: utf-8
-from prexview import Prexview
+from prexview import PrexView
 
-pxv = Prexview()
+pxv = PrexView()
 options = {'design': 'custom-invoice', 'output': 'pdf'}
 
 json = {
@@ -21,6 +21,6 @@ try:
     f.write(res['file'])
     f.close()
 
-  print 'File created:', file
+  print('File created:', file)
 except Exception as e:
-  print e
+  print(e)

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1,7 +1,7 @@
 # coding: utf-8
-from prexview import Prexview
+from prexview import PrexView
 
-pxv = Prexview()
+pxv = PrexView()
 options = dict(design='custom-invoice', output='pdf')
 
 xml = '''<?xml version="1.0" encoding="UTF-8"?>
@@ -20,6 +20,6 @@ try:
     f.write(res['file'])
     f.close()
 
-  print 'File created:', file
+  print('File created:', file)
 except Exception as e:
-  print e
+  print(e)


### PR DESCRIPTION
- Fix python 3.6+ issues
Upper version from python 3.6 requires to compare using `==` or `!=`
when comparing againts literal strings or numbers, it also requires
to use the work `as` on exceptions, and use the parenthesis when
calling the method `print`. This also fixes the tests to be case
sensitive when using unix/linux.

- Improve error messages
Currently we are raising a HTTPError using the method `raise_for_status`
from the `Requests` library, this doesn't takes the information
returned from the API with the explaination of why the API could
not create the file, instead we are parsing the response from the
API and raising an `Exception` with the error.

Fixes #3 